### PR TITLE
📆  dateをからでも登録できるようにする

### DIFF
--- a/front/src/hooks/form/useFormCreateUpdateLinks.ts
+++ b/front/src/hooks/form/useFormCreateUpdateLinks.ts
@@ -57,7 +57,9 @@ export const useFormCreateUpdateLinks = (
     resolver: yupResolver(schema),
     defaultValues: {
       ...travelinkData,
-      date: formatedDate as [Date | null, Date | null]
+      date: formatedDate
+        ? (formatedDate as [Date | null, Date | null])
+        : [null, null]
     }
   })
 


### PR DESCRIPTION
## 💫 関連Issues
close #131 

## 💪🏻 変更したこと
- nullを入れる

## 👀 確認項目
- localhost:3000/create
- dateがからでも登録できるようになっていること