### PR TITLE
🏃 初回登録時の遷移先の修正

### DIFF
--- a/front/src/hooks/auth/useCheckAuth.tsx
+++ b/front/src/hooks/auth/useCheckAuth.tsx
@@ -23,7 +23,7 @@ export const UseCheckAuth = ({ children }: UseCheckAuthProps) => {
     if (isAccessibleBeforeSignIn) return
     try {
       const auth = getAuth()
-      await onAuthStateChanged(auth, (currentUser) => {
+      onAuthStateChanged(auth, (currentUser) => {
         if (currentUser) {
           setCurrentUser({
             uid: currentUser.uid,

--- a/front/src/hooks/auth/useSignInAnonymously.ts
+++ b/front/src/hooks/auth/useSignInAnonymously.ts
@@ -2,15 +2,16 @@ import { useRouter } from 'next/router'
 import { getAuth, onAuthStateChanged, signInAnonymously } from 'firebase/auth'
 import { useSetRecoilState } from 'recoil'
 import { useBoolean } from '@chakra-ui/react'
-import { currentUserState } from '@/recoil/atoms'
+import { currentUserState, historyState } from '@/recoil/atoms'
 import { useCreateUser } from '@/hooks/firestore'
 
 export const useSignInAnonymously = () => {
-  const [disabled, setDisabled] = useBoolean()
   const router = useRouter()
+  const [disabled, setDisabled] = useBoolean()
   const setCurrentUser = useSetRecoilState(currentUserState)
+  const setHistory = useSetRecoilState(historyState)
 
-  const createUser = useCreateUser
+  const { createUser } = useCreateUser()
 
   const signInAnonymouslyHandler = async () => {
     setDisabled.on()
@@ -25,11 +26,12 @@ export const useSignInAnonymously = () => {
             isAnonymous: currentUser.isAnonymous
           })
           createUser(currentUser)
+          
         } else {
           setCurrentUser(null)
         }
       })
-
+      setHistory('/')
       router.push('/user')
     } catch (err) {
       console.error(err)

--- a/front/src/hooks/auth/useSignInAnonymously.ts
+++ b/front/src/hooks/auth/useSignInAnonymously.ts
@@ -26,7 +26,6 @@ export const useSignInAnonymously = () => {
             isAnonymous: currentUser.isAnonymous
           })
           createUser(currentUser)
-          
         } else {
           setCurrentUser(null)
         }

--- a/front/src/hooks/auth/useSignInAnonymously.ts
+++ b/front/src/hooks/auth/useSignInAnonymously.ts
@@ -1,33 +1,16 @@
 import { useRouter } from 'next/router'
 import { getAuth, onAuthStateChanged, signInAnonymously } from 'firebase/auth'
-import {
-  getFirestore,
-  collection,
-  doc,
-  getDoc,
-  setDoc
-} from 'firebase/firestore'
 import { useSetRecoilState } from 'recoil'
 import { useBoolean } from '@chakra-ui/react'
-import { CurrentUser } from '@/types/db'
 import { currentUserState } from '@/recoil/atoms'
+import { useCreateUser } from '@/hooks/firestore'
 
 export const useSignInAnonymously = () => {
   const [disabled, setDisabled] = useBoolean()
   const router = useRouter()
   const setCurrentUser = useSetRecoilState(currentUserState)
 
-  const createUserIfNotFound = async (user: CurrentUser) => {
-    const db = getFirestore()
-    const usersCollection = collection(db, 'users')
-    const userRef = doc(usersCollection, user.uid)
-    const document = await getDoc(userRef)
-    if (document.exists()) return
-    await setDoc(userRef, {
-      uid: user.uid,
-      isAnonymous: user.isAnonymous
-    })
-  }
+  const createUser = useCreateUser
 
   const signInAnonymouslyHandler = async () => {
     setDisabled.on()
@@ -41,11 +24,12 @@ export const useSignInAnonymously = () => {
             uid: currentUser.uid,
             isAnonymous: currentUser.isAnonymous
           })
-          createUserIfNotFound(currentUser)
+          createUser(currentUser)
         } else {
           setCurrentUser(null)
         }
       })
+
       router.push('/user')
     } catch (err) {
       console.error(err)

--- a/front/src/hooks/firestore/index.ts
+++ b/front/src/hooks/firestore/index.ts
@@ -1,10 +1,13 @@
+// user
+export { useCreateUser } from '@/hooks/firestore/user/useCreateUser'
+
 // travelink
 export { useGetTravelink } from '@/hooks/firestore/travelink/useGetTravelink'
 export { useGetTravelinkList } from '@/hooks/firestore/travelink/useGetTravelinkList'
 export { useCreateTravelink } from '@/hooks/firestore/travelink/useCreateTravelink'
 export { useUpdateTravelink } from '@/hooks/firestore/travelink/useUpdateTravelink'
 
-//
+// profile
 export { useGetOwnerProfile } from '@/hooks/firestore/profile/useGetOwnerProfile'
 
 // bookmark

--- a/front/src/hooks/firestore/user/useCreateUser.ts
+++ b/front/src/hooks/firestore/user/useCreateUser.ts
@@ -8,18 +8,17 @@ import {
   setDoc
 } from 'firebase/firestore'
 
-export const useCreateUser =  () => {
+export const useCreateUser = () => {
   const router = useRouter()
-
 
   const createUser = async (user: User) => {
     const db = getFirestore()
     const usersCollection = collection(db, 'users')
     const userRef = doc(usersCollection, user.uid)
     const document = await getDoc(userRef)
-  
+
     if (document.exists()) router.push('/home')
-  
+
     await setDoc(userRef, {
       uid: user.uid,
       isAnonymous: user.isAnonymous

--- a/front/src/hooks/firestore/user/useCreateUser.ts
+++ b/front/src/hooks/firestore/user/useCreateUser.ts
@@ -1,0 +1,22 @@
+import { User } from 'firebase/auth'
+import {
+  getDoc,
+  doc,
+  collection,
+  getFirestore,
+  setDoc
+} from 'firebase/firestore'
+
+export const useCreateUser = async (user: User) => {
+  const db = getFirestore()
+  const usersCollection = collection(db, 'users')
+  const userRef = doc(usersCollection, user.uid)
+  const document = await getDoc(userRef)
+
+  if (document.exists()) return
+
+  await setDoc(userRef, {
+    uid: user.uid,
+    isAnonymous: user.isAnonymous
+  })
+}

--- a/front/src/hooks/firestore/user/useCreateUser.ts
+++ b/front/src/hooks/firestore/user/useCreateUser.ts
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router'
 import { User } from 'firebase/auth'
 import {
   getDoc,
@@ -7,16 +8,23 @@ import {
   setDoc
 } from 'firebase/firestore'
 
-export const useCreateUser = async (user: User) => {
-  const db = getFirestore()
-  const usersCollection = collection(db, 'users')
-  const userRef = doc(usersCollection, user.uid)
-  const document = await getDoc(userRef)
+export const useCreateUser =  () => {
+  const router = useRouter()
 
-  if (document.exists()) return
 
-  await setDoc(userRef, {
-    uid: user.uid,
-    isAnonymous: user.isAnonymous
-  })
+  const createUser = async (user: User) => {
+    const db = getFirestore()
+    const usersCollection = collection(db, 'users')
+    const userRef = doc(usersCollection, user.uid)
+    const document = await getDoc(userRef)
+  
+    if (document.exists()) router.push('/home')
+  
+    await setDoc(userRef, {
+      uid: user.uid,
+      isAnonymous: user.isAnonymous
+    })
+  }
+
+  return { createUser }
 }

--- a/front/src/hooks/form/useCreateUpdateUserProfile.ts
+++ b/front/src/hooks/form/useCreateUpdateUserProfile.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage'
 import {
@@ -11,7 +12,7 @@ import {
 } from 'firebase/firestore'
 import { Profile } from '@/types/db'
 import { useRecoilValue } from 'recoil'
-import { currentUserState } from '@/recoil/atoms'
+import { currentUserState, historyState } from '@/recoil/atoms'
 import * as yup from 'yup'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { useBoolean } from '@chakra-ui/react'
@@ -25,13 +26,17 @@ const schema = yup.object({
 })
 
 export const useCreateUpdateUserProfile = () => {
+  const router = useRouter()
+
   const {
     register,
     handleSubmit,
     formState: { errors }
   } = useForm<Inputs>({ resolver: yupResolver(schema) })
 
+  const history = useRecoilValue(historyState)
   const currentUser = useRecoilValue(currentUserState)
+
   const firestorage = getStorage()
   const [image, setImage] = useState<File | null>()
   const [name, setName] = useState('')
@@ -117,10 +122,9 @@ export const useCreateUpdateUserProfile = () => {
         }
 
         createProfileIfNotFound(req)
-
-        // TODO: アラートをいい感じに表示する
-        alert('保存されました')
       }
+
+      if (history === '/') router.push('/home')
     } catch (err) {
       setError(true)
     } finally {

--- a/front/src/recoil/atoms/history.ts
+++ b/front/src/recoil/atoms/history.ts
@@ -1,0 +1,7 @@
+import { atom } from 'recoil'
+import { AtomKeys } from '@/recoil/keys'
+
+export const historyState = atom<string | undefined>({
+  key: AtomKeys.ROUTE_HISTORY,
+  default: undefined
+})

--- a/front/src/recoil/atoms/index.ts
+++ b/front/src/recoil/atoms/index.ts
@@ -1,1 +1,2 @@
 export { currentUserState } from '@/recoil/atoms/user'
+export { historyState } from '@/recoil/atoms/history'

--- a/front/src/recoil/keys.ts
+++ b/front/src/recoil/keys.ts
@@ -1,3 +1,4 @@
 export enum AtomKeys {
-  CURRENT_USER_STATE = 'userState'
+  CURRENT_USER_STATE = 'userState',
+  ROUTE_HISTORY = 'history'
 }


### PR DESCRIPTION
## 💫 関連Issues
close #127

## 💪🏻 変更したこと
- 若干リファクタ
- 遷移先修正
  - globalStateで、遷移する一つ前のhistoryを保持しています
  - next.jsのrouterはhistoryのstateをもてないらしいのでrecoilで実装した

## 👀 確認項目
- http://localhost:3000
- 認証済みの場合、登録ボタンを押すと/homeに遷移する
- 未認証(初回登録)のユーザは、登録ボタンを押すと/userに遷移する
  - その後、ユーザを作成ボタンを押すと、/homeに遷移する
  - 別の方法で/userにアクセスした場合は、遷移しない