### PR TITLE
トーストの表示位置を修正

### DIFF
--- a/front/src/components/Toasts/baseToastContainer.css
+++ b/front/src/components/Toasts/baseToastContainer.css
@@ -8,8 +8,19 @@
 }
 
 .Toastify__toast-container {
-
+  top: 0 !important;
+    left: 50% !important;
+    transform: translateX(-50%) !important;
 }
+
+@media only screen and (max-width: 480px) {
+  .Toastify__toast-container {
+    width: 32rem !important;
+    padding: 0.4rem !important;
+    top: 0 !important;
+      left: 50% !important;
+      transform: translateX(-50%) !important;
+  }}
 
 .Toastify__toast {
   margin: 0.9rem 1.6rem !important;
@@ -63,7 +74,6 @@
 /* Success */
 .Toastify__toast--success {
   width: 27rem !important;
-  margin-left:5.25rem !important;
   border: 0.2rem solid #67c23a;
   background: linear-gradient(
       0deg,


### PR DESCRIPTION
## 💫 関連Issues
close #203 

## 💪🏻 変更したこと
- 画面幅480px以下のときにトーストが左よりになるのを修正

## 👀 確認項目
- 該当ローカルホストの URL
- http://localhost:3000/user
- 以下確認してほしい部分のリスト
- 決定ボタンを押す→トーストが中央に表示される
